### PR TITLE
Added  app development domain model

### DIFF
--- a/3D Domain City Model Project/app-development-domain-model.md
+++ b/3D Domain City Model Project/app-development-domain-model.md
@@ -1,0 +1,5 @@
+ drive link : https://drive.google.com/drive/folders/1JKdhUiNm2YUfuuPJHiKDk2KnyyLW8dcL?usp=drive_link
+
+ <img width="655" height="658" alt="appd" src="https://github.com/user-attachments/assets/8f545af0-e8b7-4e0d-b738-3f100455a82c" />
+ 
+<img width="442" height="641" alt="Screenshot 2026-02-22 174032" src="https://github.com/user-attachments/assets/48d9100e-4674-4741-8a1d-f2186481ccbd" />


### PR DESCRIPTION
Added a drive link and images to the app development domain model documentation.
colored ss of model:

<img width="406" height="612" alt="Screenshot 2026-02-23 022404" src="https://github.com/user-attachments/assets/d18f86ba-6993-493f-a468-090ee273392f" />
<img width="463" height="570" alt="Screenshot 2026-02-23 022421" src="https://github.com/user-attachments/assets/1c76b6a5-5181-4e63-a025-414062ad9b1e" />
